### PR TITLE
Allow editing of refItems

### DIFF
--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -90,7 +90,7 @@ trait UpdateTrait
 			foreach( $list as $subentry )
 			{
 				$listItem = $listItems->pop() ?: $manager->createListItem();
-				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'] ) : null;
+				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
 
 				if( isset( $subentry['item']['address'] ) && $refItem instanceof \Aimeos\MShop\Common\Item\AddressRef\Iface ) {
 					$refItem = $this->updateAddresses( $domainManager, $refItem, $subentry['item']['address'] );


### PR DESCRIPTION
### Problem
When doing update queries, previously it was impossible to modify referenced items. List items could be updated if the id was passed, but not the actualy referenced item from other domains. It would be really useful for example to update products with variants in a single query.

### Cause
In `UpdateTrait.php` when creating the main item using 
```php
$item->fromArray( $entry, true );
```
the `private` flag is set to true to allow passing and id and edit an existing item. This is however not set to true when creating refItems the same way, which causes it to always try and create a new item. Because of thios, it was not possible to try and pass an updated existing item as a refItem.
```php
$domainManager->create()->fromArray( $subentry['item'] );
```

### Fix
Allow the updating of refItems via the graphql API by setting the private flag to true when creating the refItem. This allows passing the ids of refItems and updating those, instead of having to pass the separately.