### PR TITLE
Include properties when fetching resources

### DIFF
--- a/src/Admin/Graphql/Base.php
+++ b/src/Admin/Graphql/Base.php
@@ -186,7 +186,7 @@ abstract class Base
 				throw new \Aimeos\Admin\Graphql\Exception( 'Parameter "input" must not be empty' );
 			}
 
-			$ref = array_keys( $entry['lists'] ?? [] );
+			$ref = array_merge(array_keys( $entry['lists'] ?? [] ), $entry['property'] ? [$domain.'/property'] : [] );
 			$manager = \Aimeos\MShop::create( $context, $domain );
 
 			if( isset( $entry[$domain . '.id'] ) ) {
@@ -226,7 +226,8 @@ abstract class Base
 			$ids = array_filter( array_column( $entries, $domain . '.id' ) );
 			$filter = $manager->filter()->add( $domain . '.id', '==', $ids )->slice( 0, count( $entries ) );
 
-			$products = $manager->search( $filter, array_keys( $entry['lists'] ?? [] ) );
+			$ref = array_merge(array_keys( $entry['lists'] ?? [] ), $entry['property'] ? [$domain.'/property'] : [] );
+			$products = $manager->search( $filter, $ref );
 
 			$items = [];
 			foreach( $entries as $entry )


### PR DESCRIPTION
### Bug
Properties were never updated or deleted, only added when included with resources such as products.

### Problem
The current code that fetches the data for existing products only took the list of resources to include from the `lists` part, but didn't check if proeprties needed to be included. This caused existing properties to never be fetched and thus never updated or deleted.

### Fix
Check if proeprties exist in the payload data and include then when fetching existing items if needed.

Added both for `saveItem` and `saveItems` so that it should work both when saving/modifiyng single and multiple items.

Would also be nice to get this fix added to 2022.10.x-dev if possible.