### PR TITLE
Preserve sub listItems when updating

### DIFF
--- a/src/Admin/Graphql/Base.php
+++ b/src/Admin/Graphql/Base.php
@@ -186,8 +186,7 @@ abstract class Base
 				throw new \Aimeos\Admin\Graphql\Exception( 'Parameter "input" must not be empty' );
 			}
 
-      $ref = $this->getRefs( $entry );
-
+			$ref = $this->getRefs( $entry );
 			$manager = \Aimeos\MShop::create( $context, $domain );
 
 			if( isset( $entry[$domain . '.id'] ) ) {
@@ -227,14 +226,12 @@ abstract class Base
 			$ids = array_filter( array_column( $entries, $domain . '.id' ) );
 			$filter = $manager->filter()->add( $domain . '.id', '==', $ids )->slice( 0, count( $entries ) );
 
-            $ref = [];
-            foreach ( $entries as $entry )
-            {
-                $ref = array_merge( $ref, $this->getRefs( $entry ) );
-            }
-            $ref = array_unique( $ref );
+			$ref = [];
+			foreach( $entries as $entry ) {
+				$ref = array_merge( $ref, $this->getRefs( $entry ) );
+			}
 
-			$products = $manager->search( $filter, $ref );
+			$products = $manager->search( $filter, array_unique( $ref ) );
 			$items = [];
 
 			foreach( $entries as $entry )
@@ -248,26 +245,27 @@ abstract class Base
 	}
 
 
-  /**
-   * Recursively collect all referenced domains
-   * @param array $entry Entry or subentry with input data
-   * @return array Array with all domains collected
-   */
-  protected function getRefs( array $entry ): array
-  {
-    $ref = array_keys( $entry['lists'] ?? [] );
-    foreach ( $entry['lists'] ?? [] as $domain => $subentry )
-    {
-      foreach ( $subentry ?? [] as $subItem )
-      {
-        $ref = array_merge( $ref, $this->getRefs( $subItem['item'] ?? [] ) );
-      }
-    }
-    if( isset( $entry['property'] ) ) {
-      $ref[] = $domain . '/property';
-    }
-    return array_unique( $ref );
-  }
+	/**
+	 * Recursively collect all referenced domains
+	 * @param array $entry Entry or subentry with input data
+	 * @return array Array with all domains collected
+	 */
+	protected function getRefs( array $entry ): array
+	{
+		$ref = array_keys( $entry['lists'] ?? [] );
+		foreach( $entry['lists'] ?? [] as $domain => $subentry )
+		{
+			foreach( $subentry ?? [] as $subItem ) {
+				$ref = array_merge( $ref, $this->getRefs( $subItem['item'] ?? [] ) );
+			}
+		}
+		
+		if( isset( $entry['property'] ) ) {
+			$ref[] = $domain . '/property';
+		}
+		
+		return array_unique( $ref );
+	}
 
 
 	/**

--- a/src/Admin/Graphql/Base.php
+++ b/src/Admin/Graphql/Base.php
@@ -186,10 +186,7 @@ abstract class Base
 				throw new \Aimeos\Admin\Graphql\Exception( 'Parameter "input" must not be empty' );
 			}
 
-			$ref = array_keys( $entry['lists'] ?? [] );
-			if( isset( $entry['property'] ) ) {
-				$ref[] = $domain . '/property';
-			}
+      $ref = $this->getRefs( $entry );
 
 			$manager = \Aimeos\MShop::create( $context, $domain );
 
@@ -230,10 +227,12 @@ abstract class Base
 			$ids = array_filter( array_column( $entries, $domain . '.id' ) );
 			$filter = $manager->filter()->add( $domain . '.id', '==', $ids )->slice( 0, count( $entries ) );
 
-			$ref = array_keys( $entry['lists'] ?? [] );
-			if( isset( $entry['property'] ) ) {
-				$ref[] = $domain . '/property';
-			}
+            $ref = [];
+            foreach ( $entries as $entry )
+            {
+                $ref = array_merge( $ref, $this->getRefs( $entry ) );
+            }
+            $ref = array_unique( $ref );
 
 			$products = $manager->search( $filter, $ref );
 			$items = [];
@@ -247,6 +246,28 @@ abstract class Base
 			return $manager->save( $items );
 		};
 	}
+
+
+  /**
+   * Recursively collect all referenced domains
+   * @param array $entry Entry or subentry with input data
+   * @return array Array with all domains collected
+   */
+  protected function getRefs( array $entry ): array
+  {
+    $ref = array_keys( $entry['lists'] ?? [] );
+    foreach ( $entry['lists'] ?? [] as $domain => $subentry )
+    {
+      foreach ( $subentry ?? [] as $subItem )
+      {
+        $ref = array_merge( $ref, $this->getRefs( $subItem['item'] ?? [] ) );
+      }
+    }
+    if( isset( $entry['property'] ) ) {
+      $ref[] = $domain . '/property';
+    }
+    return array_unique( $ref );
+  }
 
 
 	/**

--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -92,19 +92,13 @@ trait UpdateTrait
 				$id = $subentry['item'][$domain.'.id'] ?? '';
 				
 				$listItem = $listItems->find( function( $item ) use ( $id ) {
-				    return $id === $item->getRefId();
+				    return $id == $item->getRefId();
 				}, $manager->createListItem() );
 				
 				unset( $listItems[$listItem->getId()] );
 
-				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
-
-				if( $oldRefItem = $listItem->getRefItem() ) {
-				    foreach ( $oldRefItem->getListItems() as $subListItem )
-				    {
-					$refItem->addListItem($subListItem->getDomain(), $subListItem, $subListItem->getRefItem());
-				    }
-				}
+				$refItem = $listItem->getRefItem() ?: $domainManager->create();
+				$refItem->fromArray( $subentry['item'] ?? [], true );
 
 				if( isset( $subentry['item']['address'] ) && $refItem instanceof \Aimeos\MShop\Common\Item\AddressRef\Iface ) {
 					$refItem = $this->updateAddresses( $domainManager, $refItem, $subentry['item']['address'] );

--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -101,8 +101,6 @@ trait UpdateTrait
 					$refItem->addListItem($subListItem->getDomain(), $subListItem, $subListItem->getRefItem());
 				    }
 				}
-				
-				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
 
 				if( isset( $subentry['item']['address'] ) && $refItem instanceof \Aimeos\MShop\Common\Item\AddressRef\Iface ) {
 					$refItem = $this->updateAddresses( $domainManager, $refItem, $subentry['item']['address'] );

--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -85,17 +85,21 @@ trait UpdateTrait
 		foreach( $entries as $domain => $list )
 		{
 			$domainManager = \Aimeos\MShop::create( $this->context(), $domain );
-			$listItems = $item->getListItems( $domain )->reverse();
+			$listItems = $item->getListItems( $domain );
 
 			foreach( $list as $subentry )
 			{
-				$listItem = $listItems->find( function ( $value ) use ( $subentry, $domain ) {
-				    return ( $subentry['item'][$domain.'.id'] ?? '' ) === $value->getRefId();
+				$id = $subentry['item'][$domain.'.id'] ?? '';
+				
+				$listItem = $listItems->find( function( $item ) use ( $id ) {
+				    return $id === $item->getRefId();
 				}, $manager->createListItem() );
-				$listItems->remove( [$listItem->getId()] );
+				
+				unset( $listItems[$listItem->getId()] );
 
 				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
-				if ( $oldRefItem = $listItem->getRefItem() ) {
+
+				if( $oldRefItem = $listItem->getRefItem() ) {
 				    foreach ( $oldRefItem->getListItems() as $subListItem )
 				    {
 					$refItem->addListItem($subListItem->getDomain(), $subListItem, $subListItem->getRefItem());

--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -90,15 +90,18 @@ trait UpdateTrait
 			foreach( $list as $subentry )
 			{
 				$id = $subentry['item'][$domain.'.id'] ?? '';
-				
+
 				$listItem = $listItems->find( function( $item ) use ( $id ) {
 				    return $id == $item->getRefId();
 				}, $manager->createListItem() );
-				
+
 				unset( $listItems[$listItem->getId()] );
 
-				$refItem = $listItem->getRefItem() ?: $domainManager->create();
-				$refItem->fromArray( $subentry['item'] ?? [], true );
+				$refItem = null;
+				if ( isset( $subentry['item'] ) ) {
+				    $refItem = $listItem->getRefItem() ?: $domainManager->create();
+				    $refItem->fromArray( $subentry['item'], true );
+				}
 
 				if( isset( $subentry['item']['address'] ) && $refItem instanceof \Aimeos\MShop\Common\Item\AddressRef\Iface ) {
 					$refItem = $this->updateAddresses( $domainManager, $refItem, $subentry['item']['address'] );

--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -89,7 +89,19 @@ trait UpdateTrait
 
 			foreach( $list as $subentry )
 			{
-				$listItem = $listItems->pop() ?: $manager->createListItem();
+				$listItem = $listItems->find( function ( $value ) use ( $subentry, $domain ) {
+				    return ( $subentry['item'][$domain.'.id'] ?? '' ) === $value->getRefId();
+				}, $manager->createListItem() );
+				$listItems->remove( [$listItem->getId()] );
+
+				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
+				if ( $oldRefItem = $listItem->getRefItem() ) {
+				    foreach ( $oldRefItem->getListItems() as $subListItem )
+				    {
+					$refItem->addListItem($subListItem->getDomain(), $subListItem, $subListItem->getRefItem());
+				    }
+				}
+				
 				$refItem = isset( $subentry['item'] ) ? $domainManager->create()->fromArray( $subentry['item'], true ) : null;
 
 				if( isset( $subentry['item']['address'] ) && $refItem instanceof \Aimeos\MShop\Common\Item\AddressRef\Iface ) {


### PR DESCRIPTION
### Bug
When mutation nested resources using the graphql API, trying to modify lists or list items deeper than one level does not work, but instead it tries to create new list items, which possibly causes SQL duplicate errors.
Example:
Modifying the variant attributes of a product with variants in one query:
```
saveProduct(input: {
        code: "TEST-PRODUCT"
        status: 1
        type: "select"
        label: "Test Product"
        id: "112233"
        lists:{
            product: [{
                item:{
                    id: "11223344"
                    code: "TEST-VARIANT-1"
                    type: "default"
                    status: 1
                    label: "Color variant"
                    lists:{
                        attribute: [{
                            type: "variant"
                            domain: "attribute"
                            refid: "123" // id of a color attribute
                        }]
                        ...
``` 
For this query, even though both the product with id `11223344` would exist and already have the attribute with id `123` linked, it would try to create that list item again and fail with an SQL duplicate error. If the id is changed to another color, it would not delete the old list item so the product would then have two color attributes linked.

### Problem
The bug stems from two probelms:
1. Referenced resources with domain `attribute` are not fetched from this query, since the refs are checked only from the top level `lists` object in the data.
```php
$ref = array_keys( $entry['lists'] ?? [] )
```
2. In the `UpdateTrait.php:updateLists(...)` function, even if the nested data is correctly fetched, how the list items are updated breaks this dependency chain, causing it to forget all lists deeper than the top level. This is caused since it does not actually use the old referenced items at all, but always creates a new one using 
```php
$manager->create()->fromArray(...)
```
without copying over existing sub list items.

### Fix
1. Added a helper function `getRefs( array $entry )` that recursively checks what all domains are used in the query. Added this to both `saveItem(...)` and `saveItems(...)`.
2. Added some extra logic to `updateLists(...)` that checks if a list items already exists to a referenced item using the id. If it exists, reuse that list item and copy over all sub list items from it. This way nested update queries will use existing list items when present instead of always creating new ones.
Not sure if this is the optimal way of doing this - potentially the old refItem could be used directly instead of always creating a new one and copying over sub list items.

Happy to still improve this if something is not optimal and needs to be improved to get it merged!