### PR TITLE
Add domain to gerRefs

### DIFF
--- a/src/Admin/Graphql/Base.php
+++ b/src/Admin/Graphql/Base.php
@@ -186,7 +186,7 @@ abstract class Base
 				throw new \Aimeos\Admin\Graphql\Exception( 'Parameter "input" must not be empty' );
 			}
 
-			$ref = $this->getRefs( $entry );
+			$ref = $this->getRefs( $entry, $domain );
 			$manager = \Aimeos\MShop::create( $context, $domain );
 
 			if( isset( $entry[$domain . '.id'] ) ) {
@@ -228,7 +228,7 @@ abstract class Base
 
 			$ref = [];
 			foreach( $entries as $entry ) {
-				$ref = array_merge( $ref, $this->getRefs( $entry ) );
+				$ref = array_merge( $ref, $this->getRefs( $entry, $domain ) );
 			}
 
 			$products = $manager->search( $filter, array_unique( $ref ) );
@@ -248,15 +248,16 @@ abstract class Base
 	/**
 	 * Recursively collect all referenced domains
 	 * @param array $entry Entry or subentry with input data
+	 * @param  string $domain Domain of subentry
 	 * @return array Array with all domains collected
 	 */
-	protected function getRefs( array $entry ): array
+	protected function getRefs( array $entry, string $domain ): array
 	{
 		$ref = array_keys( $entry['lists'] ?? [] );
-		foreach( $entry['lists'] ?? [] as $domain => $subentry )
+		foreach( $entry['lists'] ?? [] as $listDomain => $subentry )
 		{
 			foreach( $subentry ?? [] as $subItem ) {
-				$ref = array_merge( $ref, $this->getRefs( $subItem['item'] ?? [] ) );
+				$ref = array_merge( $ref, $this->getRefs( $subItem['item'] ?? [], $listDomain ) );
 			}
 		}
 		


### PR DESCRIPTION
### Bug
The previous PR adding the `getRefs` function used the `$domain` variable to create the property domain key. However the domain variable was not passed in the function so caused errors.

### Fix
Add domain to getRefs function since it's needed to create property domain name.