### PR TITLE
Allow list references without item data

### DIFF
--- a/src/Admin/Graphql/UpdateTrait.php
+++ b/src/Admin/Graphql/UpdateTrait.php
@@ -89,10 +89,11 @@ trait UpdateTrait
 
 			foreach( $list as $subentry )
 			{
-				$id = $subentry['item'][$domain.'.id'] ?? '';
+				$listId = $subentry['id'] ?? '';
+				$refId = $subentry['item'][$domain.'.id'] ?? $subentry['refid'] ?? '';
 
-				$listItem = $listItems->find( function( $item ) use ( $id ) {
-					return $id == $item->getRefId();
+				$listItem = $listItems->find( function( $item ) use ( $listId, $refId ) {
+					return $listId == $item->getId() || $refId == $item->getRefId();
 				}, $manager->createListItem() );
 
 				unset( $listItems[$listItem->getId()] );


### PR DESCRIPTION
## Problem
When upadting referenced/list resources, all list items for a domain need to be passed or are otherwise deleted.
Previous code checked existing list items by using the id from the item property in the data. However, this required that the full data for all the items were included, otherwise data would be overwritted. Even resources that were not modified needed to be fully included.

## Fix
Allow including list references when updating reosurces without including the referenced item data.
Instead, detect existing list items based on either `lists.id` or `refid`. This allows leaving out data that ahs not been modified, without it doing any changes to the existing data.